### PR TITLE
[PAYM-125] Add Losses and Fees options to StripeClient configuration

### DIFF
--- a/Lodgify.Payments.Stripe.Infrastructure/Services/StripeClient.cs
+++ b/Lodgify.Payments.Stripe.Infrastructure/Services/StripeClient.cs
@@ -24,6 +24,14 @@ public class StripeClient : Lodgify.Payments.Stripe.Application.Services.IStripe
                 {
                     Type = "none",
                 },
+                Losses = new AccountControllerLossesOptions
+                {
+                    Payments = "stripe",
+                },
+                Fees = new AccountControllerFeesOptions
+                {
+                    Payer = "application",
+                },
             },
             Capabilities = new AccountCapabilitiesOptions
             {


### PR DESCRIPTION
https://lodgify.atlassian.net/browse/PAYM-125

Introduced AccountControllerLossesOptions and AccountControllerFeesOptions to enhance the StripeClient setup. This allows specifying the payment processor and application fee payer settings.