### PR TITLE
[PAYM-172] Account version

### DIFF
--- a/Lodgify.Payments.Stripe.Domain/Accounts/Account.cs
+++ b/Lodgify.Payments.Stripe.Domain/Accounts/Account.cs
@@ -20,6 +20,7 @@ public class Account : Aggregate
     public DateTime ChargesEnabledSetAt { get; private set; }
     public bool DetailsSubmitted { get; private set; }
     public DateTime DetailsSubmittedSetAt { get; private set; }
+    public uint Version { get; private set; }
 
 
     private Account()
@@ -58,10 +59,10 @@ public class Account : Aggregate
             ChargesEnabledSetAt = changeRequestedAt;
             return true;
         }
-        
+
         return false;
     }
-    
+
     public bool SetDetailsSubmitted(bool detailsSubmitted, DateTime changeRequestedAt)
     {
         if (DetailsSubmittedSetAt < changeRequestedAt && DetailsSubmitted != detailsSubmitted)

--- a/Lodgify.Payments.Stripe.Infrastructure/Configurations/AccountConfiguration.cs
+++ b/Lodgify.Payments.Stripe.Infrastructure/Configurations/AccountConfiguration.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Lodgify.Payments.Stripe.Domain.Accounts;
+﻿using Lodgify.Payments.Stripe.Domain.Accounts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -22,5 +21,6 @@ public class AccountConfiguration : IEntityTypeConfiguration<Account>
         builder.Property(p => p.ControllerType);
         builder.Property(p => p.ChargesEnabled);
         builder.Property(p => p.DetailsSubmitted);
+        builder.Property(p => p.Version).IsRowVersion();
     }
 }

--- a/Lodgify.Payments.Stripe.Infrastructure/Migrations/20241013172324_AccountAddRowVersion.Designer.cs
+++ b/Lodgify.Payments.Stripe.Infrastructure/Migrations/20241013172324_AccountAddRowVersion.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Lodgify.Payments.Stripe.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Lodgify.Payments.Stripe.Infrastructure.Migrations
 {
     [DbContext(typeof(PaymentDbContext))]
-    partial class PaymentDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241013172324_AccountAddRowVersion")]
+    partial class AccountAddRowVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Lodgify.Payments.Stripe.Infrastructure/Migrations/20241013172324_AccountAddRowVersion.cs
+++ b/Lodgify.Payments.Stripe.Infrastructure/Migrations/20241013172324_AccountAddRowVersion.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Lodgify.Payments.Stripe.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AccountAddRowVersion : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                table: "Account",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "xmin",
+                table: "Account");
+        }
+    }
+}

--- a/Lodgify.Payments.Stripe.Infrastructure/UnitOfWork.cs
+++ b/Lodgify.Payments.Stripe.Infrastructure/UnitOfWork.cs
@@ -10,9 +10,9 @@ internal class UnitOfWork : IUnitOfWork
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
     }
-    
+
     public async Task CommitAsync(CancellationToken cancel)
     {
-        await _dbContext.SaveChangesAsync(cancel); 
+        await _dbContext.SaveChangesAsync(cancel);
     }
 }

--- a/Lodgify.Payments.Stripe.Server.IntegrationTests/Factories/CustomWebApplicationFactory.cs
+++ b/Lodgify.Payments.Stripe.Server.IntegrationTests/Factories/CustomWebApplicationFactory.cs
@@ -33,8 +33,10 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
         .Build();
 
     public IWireMockAdminApi WiremockClient { get; private set; }
-
+    
+    
     private IServiceScope _scope;
+    internal string DatabaseConnectionString;
     internal PaymentDbContext DbContext => _scope.ServiceProvider.GetRequiredService<PaymentDbContext>();
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -48,9 +50,9 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
         {
             services.RemoveAll(typeof(DbContextOptions<PaymentDbContext>));
 
-            var dbConnectionString = _postgresContainer.GetConnectionString();
+            DatabaseConnectionString = _postgresContainer.GetConnectionString();
             services.AddDbContext<PaymentDbContext>(
-                options => options.UseNpgsql(dbConnectionString),
+                options => options.UseNpgsql(DatabaseConnectionString),
                 contextLifetime: ServiceLifetime.Scoped,
                 optionsLifetime: ServiceLifetime.Scoped);
 

--- a/Lodgify.Payments.Stripe.Server.IntegrationTests/Shared/BaseIntegrationTest.cs
+++ b/Lodgify.Payments.Stripe.Server.IntegrationTests/Shared/BaseIntegrationTest.cs
@@ -29,6 +29,7 @@ public abstract class BaseIntegrationTest
     private readonly IWireMockAdminApi _wireMockClient;
     private readonly CustomWebApplicationFactory _factory;
     protected DbContext DbContext => _factory.DbContext;
+    protected string DatabaseConnectionString => _factory.DatabaseConnectionString;
 
     protected BaseIntegrationTest(CustomWebApplicationFactory factory)
     {

--- a/Lodgify.Payments.Stripe.Server/Middlewares/ExceptionHandlingMiddleware.cs
+++ b/Lodgify.Payments.Stripe.Server/Middlewares/ExceptionHandlingMiddleware.cs
@@ -1,5 +1,6 @@
 ﻿using Lodgify.Payments.Stripe.Application.BuildingBlocks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Stripe;
 
 namespace Lodgify.Payments.Stripe.Server.Middlewares;
@@ -45,6 +46,22 @@ public class ExceptionHandlingMiddleware : IMiddleware
             {
                 Status = StatusCodes.Status400BadRequest,
                 Title = "Business rule validation error",
+                Detail = ex.Message,
+                Instance = context.Request.Path,
+                Extensions = new Dictionary<string, object?>()
+                {
+                    { "StackTrace", ex.StackTrace }
+                }
+            };
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            _logger.LogError(ex, "Concurrency error");
+
+            problemDetails = new ProblemDetails
+            {
+                Status = StatusCodes.Status409Conflict,
+                Title = "Concurrency error",
                 Detail = ex.Message,
                 Instance = context.Request.Path,
                 Extensions = new Dictionary<string, object?>()


### PR DESCRIPTION
Task description:
https://lodgify.atlassian.net/browse/PAYM-172

Idea behind:
Prevent concurrency modifications on the same account.

Possible solutions:
- Application concurrency support
- Database concurrency support
https://learn.microsoft.com/en-us/ef/core/saving/concurrency?tabs=data-annotations

The database concurrency support sounds better because version will be always updated and there is no way to forget about it like in application concurrency support.

Fortunatelly PostgreSql support both solution and from version provider > 7.0.0 it is possible to simplify configuration -> https://www.npgsql.org/efcore/modeling/concurrency.html?tabs=data-annotations